### PR TITLE
Add other_args parameter to addUser

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -55,6 +55,11 @@ var user_arg_map = {
       return util.format('--selinux-user "%s"', SEUSER);
     }
   },
+  other_args: function(other_args){
+    if(other_args){
+      return other_args;
+    }
+  },
   username: function(){
     // do nothing here
   }

--- a/lib/user.js
+++ b/lib/user.js
@@ -57,7 +57,12 @@ var user_arg_map = {
   },
   other_args: function(other_args){
     if(other_args){
-      return other_args;
+       if(typeof(other_args)==="string"){
+         return other_args;
+       }
+       if(Arrays.isArray(other_args)){
+         return other_args.join(" ");
+       }
     }
   },
   username: function(){


### PR DESCRIPTION
It is potentially valuable to add other parameters to the useradd command that may be implementation-dependent.. This pull request adds the other_args parameter to the addUser function, which, if passed a string, adds that to the arguments list, and if passed as an array of strings, joins the strings with a single space between each and adds that to the arguments list.